### PR TITLE
Upgrade to naga 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,12 +332,12 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05089b2acdf0e6a962cdbf5e328402345a27f59fcde1a59fe97a73e8149d416f"
+version = "0.3.1"
+source = "git+https://github.com/gfx-rs/naga?tag=gfx-23#4a5ff9a0538510ff3c3efa171941bfb44fc1be9c"
 dependencies = [
  "bit-set",
  "bitflags",
+ "codespan-reporting",
  "fxhash",
  "log",
  "num-traits",
@@ -466,6 +476,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +532,12 @@ dependencies = [
  "pin-project-lite 0.1.12",
  "tokio",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,8 +332,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.3.1"
-source = "git+https://github.com/gfx-rs/naga?tag=gfx-23#4a5ff9a0538510ff3c3efa171941bfb44fc1be9c"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a462414ac6a74a8fcc2c6d235d9a92b288f22682c016cf725e75d0c9470fb515"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,18 @@ authors = ["Poly <marynczak.bartlomiej@gmail.com>"]
 edition = "2018"
 
 description = "Validate wgsl in rust projects"
-keywords = ["CLI","wgsl","cargo"]
+keywords = ["CLI", "wgsl", "cargo"]
 license = "MIT"
 repository = "https://github.com/PolyMeilex/cargo-wgsl"
 
 [dependencies]
-colored = "2.0.0"
-naga = {version="0.3.2",features = ["wgsl-in"]}
-walkdir = "2.3.1"
-
-serde = {version= "1.0.124", features=["derive"]}
-jsonrpc-stdio-server = "17.0.0"
-
+colored = "2.0"
+walkdir = "2.3"
+serde = { version = "1.0", features = ["derive"] }
+jsonrpc-stdio-server = "17.0"
 tokio = { version = "0.2", features = ["rt-core"] }
+
+[dependencies.naga]
+git = "https://github.com/gfx-rs/naga"
+tag = "gfx-23"
+features = ["wgsl-in"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,4 @@ walkdir = "2.3"
 serde = { version = "1.0", features = ["derive"] }
 jsonrpc-stdio-server = "17.0"
 tokio = { version = "0.2", features = ["rt-core"] }
-
-[dependencies.naga]
-git = "https://github.com/gfx-rs/naga"
-tag = "gfx-23"
-features = ["wgsl-in"]
+naga = { version = "0.4", features = ["wgsl-in"] }

--- a/src/cli/output_message.rs
+++ b/src/cli/output_message.rs
@@ -23,14 +23,12 @@ impl OutputMessage {
                 error,
                 line,
                 pos,
-                scopes,
             } => {
                 let arrow = "-->".blue();
                 let location = format!("{}:{}:{}", path.display(), line, pos);
                 let error = format!("{}: {}", "error".red().bold(), error);
-                let scopes = format!("{}: {:#?}", "scopes".blue().bold(), scopes);
 
-                format!("{} {}\n{}\n{}", arrow, location, error, scopes)
+                format!("{} {}\n{}", arrow, location, error)
             }
             err => {
                 format!("❌ {} \n{:#?}", path.display(), err)

--- a/src/naga.rs
+++ b/src/naga.rs
@@ -1,4 +1,4 @@
-use naga::front::wgsl;
+use naga::{front::wgsl, valid::ValidationFlags};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -6,13 +6,13 @@ use serde::{Deserialize, Serialize};
 use crate::wgsl_error::WgslError;
 
 pub struct Naga {
-    validator: naga::proc::Validator,
+    validator: naga::valid::Validator,
 }
 
 impl Naga {
     pub fn new() -> Self {
         Self {
-            validator: naga::proc::Validator::new(),
+            validator: naga::valid::Validator::new(ValidationFlags::all()),
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -58,12 +58,11 @@ pub fn run() {
                     match err {
                         WgslError::ParserErr {
                             error,
-                            scopes,
                             line,
                             pos,
                         } => ValidateFileResponse::ParserErr {
                             error,
-                            scopes: scopes.into_iter().map(|s| format!("{:?}", s)).collect(),
+                            scopes: vec![],
                             line,
                             pos,
                         },

--- a/src/wgsl_error.rs
+++ b/src/wgsl_error.rs
@@ -1,5 +1,5 @@
 use naga::{
-    front::wgsl::{ParseError, Scope},
+    front::wgsl::ParseError,
     valid::ValidationError,
 };
 
@@ -8,7 +8,6 @@ pub enum WgslError {
     ValidationErr(ValidationError),
     ParserErr {
         error: String,
-        scopes: Vec<Scope>,
         line: usize,
         pos: usize,
     },
@@ -27,7 +26,6 @@ impl<'a> From<ParseError<'a>> for WgslError {
         let error = err.emit_to_string();
         Self::ParserErr {
             error,
-            scopes: vec![],
             line,
             pos,
         }

--- a/src/wgsl_error.rs
+++ b/src/wgsl_error.rs
@@ -1,6 +1,6 @@
 use naga::{
     front::wgsl::{ParseError, Scope},
-    proc::ValidationError,
+    valid::ValidationError,
 };
 
 #[derive(Debug)]
@@ -23,17 +23,11 @@ impl From<std::io::Error> for WgslError {
 
 impl<'a> From<ParseError<'a>> for WgslError {
     fn from(err: ParseError<'a>) -> Self {
-        let ParseError {
-            error,
-            scopes,
-            line,
-            pos,
-        } = err;
-        let error = error.to_owned();
-
+        let (line, pos) = err.location();
+        let error = err.emit_to_string();
         Self::ParserErr {
-            error: error.to_string(),
-            scopes,
+            error,
+            scopes: vec![],
             line,
             pos,
         }


### PR DESCRIPTION
Draft because I haven't found a replacement for the `scopes` attribute yet. If there's no replacement, do you think this would be much of a loss @PolyMeilex? Also, some errors highlight the whole file, e.g., if I try to add an integer to a floating point number. I would expect this to only highlight the addition itself, but I suppose that is an issue on naga's end:

<img width="539" alt="Bildschirmfoto 2021-04-30 um 22 39 39" src="https://user-images.githubusercontent.com/590517/116751892-f4e26180-aa04-11eb-90cf-6571fff6bffe.png">
