### PR TITLE
Update to naga 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cargo-wgsl"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "colored",
  "jsonrpc-stdio-server",
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a462414ac6a74a8fcc2c6d235d9a92b288f22682c016cf725e75d0c9470fb515"
+checksum = "ef670817eef03d356d5a509ea275e7dd3a78ea9e24261ea3cb2dfed1abb08f64"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-wgsl"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Poly <marynczak.bartlomiej@gmail.com>"]
 edition = "2018"
 
@@ -15,4 +15,4 @@ walkdir = "2.3"
 serde = { version = "1.0", features = ["derive"] }
 jsonrpc-stdio-server = "17.0"
 tokio = { version = "0.2", features = ["rt-core"] }
-naga = { version = "0.4", features = ["wgsl-in"] }
+naga = { version = "0.5", features = ["wgsl-in"] }

--- a/src/naga.rs
+++ b/src/naga.rs
@@ -1,4 +1,7 @@
-use naga::{front::wgsl, valid::ValidationFlags};
+use naga::{
+    front::wgsl,
+    valid::{Capabilities, ValidationFlags},
+};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -12,13 +15,14 @@ pub struct Naga {
 impl Naga {
     pub fn new() -> Self {
         Self {
-            validator: naga::valid::Validator::new(ValidationFlags::all()),
+            validator: naga::valid::Validator::new(ValidationFlags::all(), Capabilities::all()),
         }
     }
 
     pub fn validate_wgsl(&mut self, path: &Path) -> Result<(), WgslError> {
         let shader = std::fs::read_to_string(&path).map_err(WgslError::from)?;
-        let module = wgsl::parse_str(&shader).map_err(WgslError::from)?;
+        let module =
+            wgsl::parse_str(&shader).map_err(|err| WgslError::from_parse_err(err, &shader))?;
 
         if let Err(err) = self.validator.validate(&module) {
             Err(WgslError::ValidationErr(err))
@@ -29,7 +33,8 @@ impl Naga {
 
     pub fn get_wgsl_tree(&mut self, path: &Path) -> Result<WgslTree, WgslError> {
         let shader = std::fs::read_to_string(&path).map_err(WgslError::from)?;
-        let module = wgsl::parse_str(&shader).map_err(WgslError::from)?;
+        let module =
+            wgsl::parse_str(&shader).map_err(|err| WgslError::from_parse_err(err, &shader))?;
 
         let mut types = Vec::new();
         let mut global_variables = Vec::new();

--- a/src/wgsl_error.rs
+++ b/src/wgsl_error.rs
@@ -1,7 +1,4 @@
-use naga::{
-    front::wgsl::ParseError,
-    valid::ValidationError,
-};
+use naga::{front::wgsl::ParseError, valid::ValidationError};
 
 #[derive(Debug)]
 pub enum WgslError {
@@ -20,14 +17,10 @@ impl From<std::io::Error> for WgslError {
     }
 }
 
-impl<'a> From<ParseError<'a>> for WgslError {
-    fn from(err: ParseError<'a>) -> Self {
-        let (line, pos) = err.location();
-        let error = err.emit_to_string();
-        Self::ParserErr {
-            error,
-            line,
-            pos,
-        }
+impl WgslError {
+    pub fn from_parse_err(err: ParseError, src: &str) -> Self {
+        let (line, pos) = err.location(src);
+        let error = err.emit_to_string(src);
+        Self::ParserErr { error, line, pos }
     }
 }


### PR DESCRIPTION
Matches recent release of wgpu 0.9. Note that `naga::front::wgsl::ParseError` doesn't store the shader source anymore and now requires it to be passed explicitly when calling `err.location` or `err.emit_to_string`.