### PR TITLE
Have better CLI errors

### DIFF
--- a/src/cli/output_message.rs
+++ b/src/cli/output_message.rs
@@ -26,6 +26,9 @@ impl OutputMessage {
 
                 format!("{} {}\n{}", arrow, location, error)
             }
+            WgslError::ValidationErr { error, emitted, .. } => {
+                format!("❌ {} \n{:?} {}", path.display(), error, emitted)
+            }
             err => {
                 format!("❌ {} \n{:#?}", path.display(), err)
             }

--- a/src/naga.rs
+++ b/src/naga.rs
@@ -25,7 +25,7 @@ impl Naga {
             wgsl::parse_str(&shader).map_err(|err| WgslError::from_parse_err(err, &shader))?;
 
         if let Err(error) = self.validator.validate(&module) {
-            Err(WgslError::ValidationErr { src: shader, error })
+            Err(WgslError::ValidationErr { emitted: error.emit_to_string(&shader), src: shader, error })
         } else {
             Ok(())
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -67,7 +67,7 @@ pub fn run() {
                                 pos,
                             }
                         }
-                        WgslError::ValidationErr { src, error } => {
+                        WgslError::ValidationErr { src, error, .. } => {
                             if let Some((span, _)) = error.spans().next() {
                                 let loc = span.location(&src);
                                 ValidateFileResponse::ParserErr {

--- a/src/wgsl_error.rs
+++ b/src/wgsl_error.rs
@@ -5,6 +5,7 @@ pub enum WgslError {
     ValidationErr {
         src: String,
         error: WithSpan<ValidationError>,
+        emitted: String,
     },
     ParserErr {
         error: String,


### PR DESCRIPTION
This uses the naga's span support and custom formatting to provide better errors for the CLI.

```
WithSpan { inner: EntryPoint { stage: Vertex, name: "vs_main", source: Function(Expression { handle: [4], source: InvalidBinaryOperandTypes(Add, [2], [3]) }) }, spans: [(Span { start: 152, end: 157 }, "naga::Expression [4]")] } error: Entry point vs_main at Vertex is invalid
  ┌─ wgsl:5:13
  │
5 │     let c = a + b;
  │             ^^^^^ naga::Expression [4]
  │
  = Expression [4] is invalid
  = Operation Add can't work with [2] and [3]
```